### PR TITLE
Prometheus metrics

### DIFF
--- a/samples/hook/hook.go
+++ b/samples/hook/hook.go
@@ -16,7 +16,7 @@ func main() {
 	if ttl, err := strconv.Atoi(strings.Trim(os.Getenv("BINDMAN_DNS_TTL"), " ")); err == nil {
 		manager.TTL = ttl
 	}
-	hook.Initialize(&manager)
+	hook.Initialize(&manager, "1")
 }
 
 // DummyManager holds the information for managing a dummy dns server

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -27,15 +27,14 @@ func Initialize(manager types.DNSManager, serviceName, serviceVersion string) {
 	prometheus := metrics.New(serviceName, serviceVersion)
 
 	router := mux.NewRouter()
-	router.HandleFunc("/records", hook.GetDNSRecords).Methods("GET")
-	router.HandleFunc("/records/{name}/{type}", hook.GetDNSRecord).Methods("GET")
-	router.HandleFunc("/records/{name}/{type}", hook.RemoveDNSRecord).Methods("DELETE")
-	router.HandleFunc("/records", hook.AddDNSRecord).Methods("POST")
-	router.HandleFunc("/records", hook.UpdateDNSRecord).Methods("PUT")
+	router.Handle(prometheus.HandleFunc("/records", hook.GetDNSRecords)).Methods("GET")
+	router.HandleFunc(prometheus.HandleFunc("/records/{name}/{type}", hook.GetDNSRecord)).Methods("GET")
+	router.HandleFunc(prometheus.HandleFunc("/records/{name}/{type}", hook.RemoveDNSRecord)).Methods("DELETE")
+	router.HandleFunc(prometheus.HandleFunc("/records", hook.AddDNSRecord)).Methods("POST")
+	router.HandleFunc(prometheus.HandleFunc("/records", hook.UpdateDNSRecord)).Methods("PUT")
 
 	// exposes /metrics endpoint with standard golang metrics used by prometheus
 	router.Handle("/metrics", promhttp.Handler())
-	router.Use(prometheus.MetricsMiddleware)
 
 	logrus.Info("Initialized DNS Manager Webhook")
 	err := http.ListenAndServe("0.0.0.0:7070", router)

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -21,10 +21,10 @@ type DNSWebhook struct {
 }
 
 // Initialize starts up a dns manager webhook
-func Initialize(manager types.DNSManager, serviceName, serviceVersion string) {
+func Initialize(manager types.DNSManager, serviceVersion string) {
 	hook := &DNSWebhook{manager}
 
-	prometheus := metrics.New(serviceName, serviceVersion)
+	prometheus := metrics.New(serviceVersion)
 
 	router := mux.NewRouter()
 	router.Handle(prometheus.HandleFunc("/records", hook.GetDNSRecords)).Methods("GET")

--- a/src/hook/hook.go
+++ b/src/hook/hook.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/labbsr0x/bindman-dns-webhook/src/hook/metrics"
 	"github.com/labbsr0x/bindman-dns-webhook/src/types"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
@@ -19,14 +21,21 @@ type DNSWebhook struct {
 }
 
 // Initialize starts up a dns manager webhook
-func Initialize(manager types.DNSManager) {
+func Initialize(manager types.DNSManager, serviceName, serviceVersion string) {
 	hook := &DNSWebhook{manager}
+
+	prometheus := metrics.New(serviceName, serviceVersion)
+
 	router := mux.NewRouter()
 	router.HandleFunc("/records", hook.GetDNSRecords).Methods("GET")
 	router.HandleFunc("/records/{name}/{type}", hook.GetDNSRecord).Methods("GET")
 	router.HandleFunc("/records/{name}/{type}", hook.RemoveDNSRecord).Methods("DELETE")
 	router.HandleFunc("/records", hook.AddDNSRecord).Methods("POST")
 	router.HandleFunc("/records", hook.UpdateDNSRecord).Methods("PUT")
+
+	// exposes /metrics endpoint with standard golang metrics used by prometheus
+	router.Handle("/metrics", promhttp.Handler())
+	router.Use(prometheus.MetricsMiddleware)
 
 	logrus.Info("Initialized DNS Manager Webhook")
 	err := http.ListenAndServe("0.0.0.0:7070", router)

--- a/src/hook/metrics/prometheus.go
+++ b/src/hook/metrics/prometheus.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
+	"time"
+)
+
+type Prometheus struct {
+	reqCount    *prometheus.CounterVec
+	reqLatency  *prometheus.HistogramVec
+	reqInFlight *prometheus.GaugeVec
+}
+
+func New(serviceName, serviceVersion string) *Prometheus {
+	p := &Prometheus{}
+	constLabels := prometheus.Labels{"service": serviceName, "service_version": serviceVersion}
+	p.reqCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:        "http_requests_total",
+			Help:        "How many HTTP requests processed, partitioned by status code, method and HTTP path.",
+			ConstLabels: constLabels,
+		},
+		[]string{"code", "method", "path"},
+	)
+	prometheus.MustRegister(p.reqCount)
+
+	p.reqLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:        "http_request_duration_seconds",
+		Help:        "How long it took to process the request, partitioned by status code, method and HTTP path.",
+		ConstLabels: constLabels,
+	},
+		[]string{"code", "method", "path"},
+	)
+	prometheus.MustRegister(p.reqLatency)
+
+	p.reqInFlight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:        "http_requests_in_flight_total",
+		Help:        "How many requests are being processed, partitioned method and HTTP path.",
+		ConstLabels: constLabels,
+	},
+		[]string{"method", "path"},
+	)
+	prometheus.MustRegister(p.reqInFlight)
+	return p
+}
+
+func (p *Prometheus) MetricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		path := r.URL.Path
+
+		p.reqInFlight.WithLabelValues(r.Method, path).Inc()
+
+		next.ServeHTTP(w, r)
+
+		p.reqInFlight.WithLabelValues(r.Method, path).Dec()
+
+		statusCode := w.Header().Get("Status-Code")
+
+		p.reqCount.WithLabelValues(statusCode, r.Method, path).
+			Inc()
+		p.reqLatency.WithLabelValues(statusCode, r.Method, path).
+			Observe(float64(time.Since(start).Seconds()) / 1000000000)
+
+	})
+}

--- a/src/hook/metrics/prometheus_test.go
+++ b/src/hook/metrics/prometheus_test.go
@@ -1,0 +1,61 @@
+package metrics
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestNew(t *testing.T) {
+	type args struct {
+		serviceName    string
+		serviceVersion string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Prometheus
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.serviceName, tt.args.serviceVersion); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrometheus_MetricsMiddleware(t *testing.T) {
+	type fields struct {
+		reqCount    *prometheus.CounterVec
+		reqLatency  *prometheus.HistogramVec
+		reqInFlight *prometheus.GaugeVec
+	}
+	type args struct {
+		next http.Handler
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   http.Handler
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prometheus{
+				reqCount:    tt.fields.reqCount,
+				reqLatency:  tt.fields.reqLatency,
+				reqInFlight: tt.fields.reqInFlight,
+			}
+			if got := p.MetricsMiddleware(tt.args.next); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Prometheus.MetricsMiddleware() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/hook/metrics/prometheus_test.go
+++ b/src/hook/metrics/prometheus_test.go
@@ -8,6 +8,52 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+func Test_newLoggingResponseWriter(t *testing.T) {
+	type args struct {
+		w http.ResponseWriter
+	}
+	tests := []struct {
+		name string
+		args args
+		want *statusCodeResponseWriter
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newLoggingResponseWriter(tt.args.w); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newLoggingResponseWriter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_statusCodeResponseWriter_WriteHeader(t *testing.T) {
+	type fields struct {
+		ResponseWriter http.ResponseWriter
+		statusCode     int
+	}
+	type args struct {
+		code int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &statusCodeResponseWriter{
+				ResponseWriter: tt.fields.ResponseWriter,
+				statusCode:     tt.fields.statusCode,
+			}
+			s.WriteHeader(tt.args.code)
+		})
+	}
+}
+
 func TestNew(t *testing.T) {
 	type args struct {
 		serviceName    string
@@ -29,20 +75,22 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestPrometheus_MetricsMiddleware(t *testing.T) {
+func TestPrometheus_HandleFunc(t *testing.T) {
 	type fields struct {
 		reqCount    *prometheus.CounterVec
 		reqLatency  *prometheus.HistogramVec
 		reqInFlight *prometheus.GaugeVec
 	}
 	type args struct {
-		next http.Handler
+		path string
+		next http.HandlerFunc
 	}
 	tests := []struct {
 		name   string
 		fields fields
 		args   args
-		want   http.Handler
+		want   string
+		want1  http.HandlerFunc
 	}{
 		// TODO: Add test cases.
 	}
@@ -53,8 +101,12 @@ func TestPrometheus_MetricsMiddleware(t *testing.T) {
 				reqLatency:  tt.fields.reqLatency,
 				reqInFlight: tt.fields.reqInFlight,
 			}
-			if got := p.MetricsMiddleware(tt.args.next); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Prometheus.MetricsMiddleware() = %v, want %v", got, tt.want)
+			got, got1 := p.HandleFunc(tt.args.path, tt.args.next)
+			if got != tt.want {
+				t.Errorf("Prometheus.HandleFunc() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("Prometheus.HandleFunc() got1 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}

--- a/src/hook/metrics/prometheus_test.go
+++ b/src/hook/metrics/prometheus_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -17,7 +18,11 @@ func Test_newLoggingResponseWriter(t *testing.T) {
 		args args
 		want *statusCodeResponseWriter
 	}{
-		// TODO: Add test cases.
+		{
+			"default status code",
+			args{},
+			&statusCodeResponseWriter{nil, http.StatusOK},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -41,7 +46,11 @@ func Test_statusCodeResponseWriter_WriteHeader(t *testing.T) {
 		fields fields
 		args   args
 	}{
-		// TODO: Add test cases.
+		{
+			"statusCodeResponseWriter.statusCode must be the same passed to WriteHeader",
+			fields{ResponseWriter: httptest.NewRecorder()},
+			args{http.StatusInternalServerError},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -50,64 +59,142 @@ func Test_statusCodeResponseWriter_WriteHeader(t *testing.T) {
 				statusCode:     tt.fields.statusCode,
 			}
 			s.WriteHeader(tt.args.code)
+			if s.statusCode != tt.args.code {
+				t.Errorf("want %d, got %d", tt.args.code, s.statusCode)
+			}
 		})
 	}
 }
 
 func TestNew(t *testing.T) {
+	newMetrics := New("1")
+	// validate all metrics have been instantiated
+	if newMetrics.reqCount == nil {
+		t.Fatalf("expected reqCount to be already instantiated")
+	}
+	if newMetrics.reqLatency == nil {
+		t.Fatalf("expected reqLatency to be already instantiated")
+	}
+	if newMetrics.reqInFlight == nil {
+		t.Fatalf("expected reqInFlight to be already instantiated")
+	}
+
+	registerValidation := func(c prometheus.Collector, t *testing.T) {
+		err := prometheus.Register(c)
+		if err == nil {
+			t.Fatal("expected s to be already registered")
+		}
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			t.Fatal("unexpected registration error:", err)
+		}
+	}
+	// must have all metrics already registered
+	registerValidation(newMetrics.reqCount, t)
+	registerValidation(newMetrics.reqLatency, t)
+	registerValidation(newMetrics.reqInFlight, t)
+}
+
+func TestNew_ValidateArgs(t *testing.T) {
 	type args struct {
-		serviceName    string
 		serviceVersion string
 	}
+	type expected struct {
+		error bool
+	}
 	tests := []struct {
-		name string
-		args args
-		want *Prometheus
+		name     string
+		args     args
+		expected expected
 	}{
-		// TODO: Add test cases.
+		{
+			"valid service version",
+			args{"1"},
+			expected{error: false},
+		}, {
+			"empty service version",
+			args{""},
+			expected{error: true},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.serviceName, tt.args.serviceVersion); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
+			resetRegistry()
+			defer func() {
+				err := recover()
+				if tt.expected.error != (err != nil) {
+					t.Fatalf("expected an error %t but got %v", tt.expected.error, err)
+				}
+			}()
+			New(tt.args.serviceVersion)
+		})
+	}
+}
+
+// TODO check metrics values after handle execution
+func TestPrometheus_HandleFunc(t *testing.T) {
+	type want struct {
+		path       string
+		method     string
+		statusCode int
+		body       string
+	}
+	tests := []struct {
+		name string
+		want want
+	}{
+		{
+			"returned path must be the same received via function parameter",
+			want{"/api/get", "GET", http.StatusPaymentRequired, "hello"},
+		},
+		{
+			"returned path must be the same received via function parameter",
+			want{"/api/post", "POST", http.StatusOK, ""},
+		},
+	}
+
+	resetRegistry()
+	p := New("1")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// handle to collect metrics from
+			next := func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.want.statusCode)
+				_, err := w.Write([]byte(tt.want.body))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			path, handle := p.HandleFunc(tt.want.path, next)
+			if path != tt.want.path {
+				t.Errorf("path must be the same provided by function parameter. got = %v, want %v", path, tt.want.path)
+			}
+
+			// metrics middleware uses only method attribute from http request
+			req := &http.Request{
+				Method: "GET",
+			}
+			resp := httptest.NewRecorder()
+
+			handle.ServeHTTP(resp, req)
+
+			// metrics middleware cannot change response status code
+			if resp.Code != tt.want.statusCode {
+				t.Fatalf("expected status %d, got %d", tt.want.statusCode, resp.Code)
+			}
+			// metrics middleware cannot change response body
+			if resp.Body.String() != tt.want.body {
+				t.Fatalf("expected body %s, got %s", tt.want.body, resp.Body.String())
 			}
 		})
 	}
 }
 
-func TestPrometheus_HandleFunc(t *testing.T) {
-	type fields struct {
-		reqCount    *prometheus.CounterVec
-		reqLatency  *prometheus.HistogramVec
-		reqInFlight *prometheus.GaugeVec
-	}
-	type args struct {
-		path string
-		next http.HandlerFunc
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-		want1  http.HandlerFunc
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &Prometheus{
-				reqCount:    tt.fields.reqCount,
-				reqLatency:  tt.fields.reqLatency,
-				reqInFlight: tt.fields.reqInFlight,
-			}
-			got, got1 := p.HandleFunc(tt.args.path, tt.args.next)
-			if got != tt.want {
-				t.Errorf("Prometheus.HandleFunc() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("Prometheus.HandleFunc() got1 = %v, want %v", got1, tt.want1)
-			}
-		})
-	}
+func resetRegistry() {
+	// reset registry
+	// Create and assign a new Prometheus Registerer/Gatherer for each test
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
 }


### PR DESCRIPTION
- Collect the following metrics
```
name: build_info 
type: gauge
description: Information about build.

name: http_requests_in_flight 
type: gauge
description: How many requests are being processed, partitioned method and HTTP path.

name: http_request_duration_seconds 
type: histogram
description: How long it took to process the request, partitioned by status code, method and HTTP path.

name: http_requests_total 
type: counter
description: How many HTTP requests processed, partitioned by status code, method and HTTP path.
```

- Add `/metrics` endpoint to export the metrics data